### PR TITLE
(bugfix): compress blank dist file in tar package sometimes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+# EditorConfig is awesome: http://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+indent_style = space
+indent_size = 4

--- a/lib/utils/filetool.js
+++ b/lib/utils/filetool.js
@@ -9,6 +9,7 @@ const cpdir = require('copy-dir');
 const mkdir = require('mkdir-p');
 const writefile = require('writefile');
 const rmdirSync = require('./rmdir-sync');
+const writeFileSync = require('./safe-writefile');
 
 module.exports = {
     /**
@@ -37,6 +38,15 @@ module.exports = {
 
     writefile: function (path, text) {
         writefile(path, text);
+    },
+
+    /**
+     * 同步写入文件，如写入目录不存在，将自动创建目录，如创建目录或写入文件时出现异常，将直接抛出该异常
+     * @param path { string } 写入文件路径
+     * @param content { string | Buffer} 写入内容
+     */
+    writeFileSync: function (path, content) {
+        writeFileSync(path, content);
     },
 
     mkdir: function (path) {

--- a/lib/utils/safe-writefile.js
+++ b/lib/utils/safe-writefile.js
@@ -1,0 +1,28 @@
+/**
+ * author : Ryan Liu braveoyster@gmail.com
+ * date   : 17 Oct 2018
+ * desc   : write file synchronous with check whether directory was exists,
+ *          inspired by 'https://github.com/jkroso/writefile'
+ **/
+
+const fs = require('fs');
+const dirname = require('path').dirname;
+const mkdirp = require('mkdirp');
+
+/**
+ * fs.writeFileSync but makes parent directories if required
+ *
+ * @param {String} path
+ * @param {String} content
+ */
+function writeFileSync(path, content) {
+    const dir = dirname(path);
+    if (!fs.existsSync(dir)) {
+        mkdirp.sync(dir, 0777);
+    }
+
+    fs.writeFileSync(path, content);
+    console.log(`\n -----------${path} 已成功写入-----------`);
+}
+
+module.exports = writeFileSync;

--- a/lib/widget/index.js
+++ b/lib/widget/index.js
@@ -40,7 +40,7 @@ module.exports = function () {
                         presets: ['es2015', 'react', 'stage-0']
                     }).code.replace('\'use strict\';', '');
 
-                    filetool.writefile(cwd + '/dist/' + item.replace(cwd + '/src/', ''), content);
+                    filetool.writeFileSync(cwd + '/dist/' + item.replace(cwd + '/src/', ''), content);
                 } else if (/\.css$/.test(item)) {
                     filetool.copyfile(item, item.replace('/src/', '/dist/'));
                 }


### PR DESCRIPTION
when you exec 'zenbone widget build'，sometimes dist file in tar package was blank, so i change 'writefile' used sync way.